### PR TITLE
feat: fetch available models and improve error detail

### DIFF
--- a/src/geminiapihandler.cpp
+++ b/src/geminiapihandler.cpp
@@ -40,16 +40,32 @@ void GeminiApiHandler::testApiConnection(const QString &apiKey)
             QByteArray responseData = reply->readAll();
             QJsonDocument jsonDoc = QJsonDocument::fromJson(responseData);
             if (jsonDoc.object().contains("models")) {
-                emit apiTestSuccess("Successfully fetched model list.");
+                QJsonArray modelsArray = jsonDoc.object()["models"].toArray();
+                QStringList modelNames;
+                for (const QJsonValue &val : modelsArray) {
+                    QString name = val.toObject()["name"].toString();
+                    if (name.startsWith("models/"))
+                        name = name.section('/', 1);
+                    modelNames.append(name);
+                }
+                emit modelsFetched(modelNames);
+                emit apiTestSuccess(QString("Fetched %1 models.").arg(modelNames.size()));
             } else if (jsonDoc.object().contains("error")) {
-                QString errorMsg = jsonDoc.object()["error"].toObject()["message"].toString();
-                emit apiTestFailed("API Error: " + errorMsg);
+                QJsonObject errorObj = jsonDoc.object()["error"].toObject();
+                int code = errorObj["code"].toInt();
+                QString errorMsg = errorObj["message"].toString();
+                emit apiTestFailed(QString("API Error (%1): %2").arg(code).arg(errorMsg));
             } else {
                 emit apiTestFailed("Unknown API response format.");
             }
         } else {
-            reply->readAll(); // Clear buffer on error
-            emit apiTestFailed("Network Error: " + reply->errorString());
+            int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            QByteArray data = reply->readAll();
+            QString err = QString("Network Error (%1): %2").arg(statusCode).arg(reply->errorString());
+            if (!data.isEmpty()) {
+                err += "\nResponse: " + QString::fromUtf8(data);
+            }
+            emit apiTestFailed(err);
         }
         reply->deleteLater();
     });
@@ -91,7 +107,7 @@ void GeminiApiHandler::translateImage(const QPixmap &image, const QStringList &a
     auto lastError = std::make_shared<QString>();
     auto sendRequest = std::make_shared<std::function<void(int)>>();
 
-    *sendRequest = [=, this, sendRequest, lastError](int index) {
+    *sendRequest = [this, sendRequest, lastError, apiKeys, urlString, jsonData](int index) {
         if (index >= apiKeys.size()) {
             emit errorOccurred(QStringLiteral("All API keys failed. Last error: %1").arg(*lastError));
             return;
@@ -107,7 +123,7 @@ void GeminiApiHandler::translateImage(const QPixmap &image, const QStringList &a
 
         QNetworkReply *reply = networkManager->post(request, jsonData);
 
-        connect(reply, &QNetworkReply::finished, this, [=, this, sendRequest, lastError, index]() {
+        connect(reply, &QNetworkReply::finished, this, [this, sendRequest, lastError, reply, index]() {
             if (reply->error() == QNetworkReply::NoError) {
                 QByteArray responseData = reply->readAll();
                 QJsonDocument jsonDoc = QJsonDocument::fromJson(responseData);
@@ -131,15 +147,23 @@ void GeminiApiHandler::translateImage(const QPixmap &image, const QStringList &a
                         (*sendRequest)(index + 1);
                     }
                 } else if (jsonObj.contains("error")) {
-                    *lastError = jsonObj["error"].toObject()["message"].toString();
+                    QJsonObject errorObj = jsonObj["error"].toObject();
+                    int code = errorObj["code"].toInt();
+                    QString message = errorObj["message"].toString();
+                    *lastError = QString("API Error (%1): %2").arg(code).arg(message);
                     (*sendRequest)(index + 1);
                 } else {
                     *lastError = QStringLiteral("API response format error: 'candidates' not found.");
                     (*sendRequest)(index + 1);
                 }
             } else {
-                reply->readAll();
-                *lastError = reply->errorString();
+                int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+                QByteArray data = reply->readAll();
+                QString err = QString("Network Error (%1): %2").arg(statusCode).arg(reply->errorString());
+                if (!data.isEmpty()) {
+                    err += "\nResponse: " + QString::fromUtf8(data);
+                }
+                *lastError = err;
                 (*sendRequest)(index + 1);
             }
             reply->deleteLater();

--- a/src/geminiapihandler.h
+++ b/src/geminiapihandler.h
@@ -24,6 +24,7 @@ signals:
     void errorOccurred(const QString &errorString);
     void apiTestSuccess(const QString &message);
     void apiTestFailed(const QString &errorString);
+    void modelsFetched(const QStringList &models);
 
 private:
     QNetworkAccessManager *networkManager;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -49,6 +49,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(settingsDialog, &SettingsDialog::apiTestRequested, this, &MainWindow::handleApiTestRequest);
     connect(apiHandler, &GeminiApiHandler::apiTestSuccess, this, &MainWindow::handleApiTestSuccess);
     connect(apiHandler, &GeminiApiHandler::apiTestFailed, this, &MainWindow::handleApiTestFailed);
+    connect(apiHandler, &GeminiApiHandler::modelsFetched, this, &MainWindow::handleAvailableModels);
 
     loadSettings();
 }
@@ -386,4 +387,11 @@ void MainWindow::handleApiTestSuccess(const QString& message) {
 void MainWindow::handleApiTestFailed(const QString& error) {
     statusLabel->setText("API test failed.");
     createStyledMessageBox(QMessageBox::Warning, "API Test Failed", "Could not connect to the Gemini API.\n\nDetails: " + error)->exec();
+}
+
+void MainWindow::handleAvailableModels(const QStringList &models) {
+    if (settingsDialog) {
+        settingsDialog->setAvailableModels(models);
+    }
+    createStyledMessageBox(QMessageBox::Information, "Available Models", models.join("\n"))->exec();
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -9,6 +9,7 @@
 #include <QMouseEvent>
 #include <QPixmap>
 #include <QRect>
+#include <QStringList>
 
 // Forward declarations
 class QPushButton;
@@ -50,6 +51,7 @@ private slots:
     void handleApiTestRequest();
     void handleApiTestSuccess(const QString& message);
     void handleApiTestFailed(const QString& error);
+    void handleAvailableModels(const QStringList &models);
 
 private:
     void setupUI();

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -145,7 +145,6 @@ void SettingsDialog::loadSettings()
     QSettings settings("ScreenTranslate", "ScreenTranslate"); // 建议使用公司和产品名
 
     setApiKeys(settings.value("apiKey").toString().split('\n', Qt::SkipEmptyParts));
-    codex/modify-default-model-to-gemini-2.5-flash
     setModelName(settings.value("modelName", "gemini-2.5-flash").toString());
     setThemeName(settings.value("theme", "Dark").toString());
     setPrompt(settings.value("prompt", "请识别图片中的文字。将识别出的原文放在第一行，将对应的翻译结果放在第二行返回。两行之间不要有任何其他内容。").toString());
@@ -194,3 +193,12 @@ void SettingsDialog::setProxyHost(const QString &host) { proxyHostEdit->setText(
 void SettingsDialog::setProxyPort(quint16 port) { proxyPortEdit->setText(QString::number(port)); }
 void SettingsDialog::setHistoryEnabled(bool enabled) { historyCheckBox->setChecked(enabled); }
 void SettingsDialog::setHistoryLength(int length) { historySpinBox->setValue(length); }
+
+void SettingsDialog::setAvailableModels(const QStringList &models) {
+    QString current = modelComboBox->currentText();
+    modelComboBox->clear();
+    modelComboBox->addItems(models);
+    if (models.contains(current)) {
+        modelComboBox->setCurrentText(current);
+    }
+}

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -40,6 +40,7 @@ public:
     void setProxyPort(quint16 port);
     void setHistoryEnabled(bool enabled);
     void setHistoryLength(int length);
+    void setAvailableModels(const QStringList &models);
 
 signals:
     void apiTestRequested();


### PR DESCRIPTION
## Summary
- fetch available model list from Gemini API
- show model choices in settings dialog
- include HTTP status and body in error messages
- fix lambda capture lists for MSVC compatibility

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68c58567ce1483278c34d2e3b3c5f751